### PR TITLE
bypass CROS

### DIFF
--- a/main.py
+++ b/main.py
@@ -123,6 +123,12 @@ def lyric_v1(id, cookies):
 
 # Flask 应用部分
 app = Flask(__name__)
+@app.after_request
+def after_request(response):
+    response.headers.add('Access-Control-Allow-Origin', '*')
+    response.headers.add('Access-Control-Allow-Headers', 'Content-Type,Authorization')
+    response.headers.add('Access-Control-Allow-Methods', 'GET,POST,OPTIONS')
+    return response
 
 @app.route('/', methods=['GET', 'POST'])
 def index():


### PR DESCRIPTION
如果用户需要进行浏览器GUI开发，很可能遇到CROS同源策略拒绝  

在这里bypass了一下CROS，允许不同源加载